### PR TITLE
Take no action if no PRs are found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,40 +131,46 @@ async fn main() -> Result<(), Error> {
         );
     }
 
-    let weekday = match chrono::offset::Local::now().date().weekday() {
-        chrono::Weekday::Mon => "Monday",
-        chrono::Weekday::Tue => "Tuesday",
-        chrono::Weekday::Wed => "Wednesday",
-        chrono::Weekday::Thu => "Thursday",
-        chrono::Weekday::Fri => "Friday",
-        chrono::Weekday::Sat => "Saturday",
-        chrono::Weekday::Sun => "Sunday",
-    };
+    if pull_requests_to_review.len() > 0 {
 
-    let mut message = String::new();
+        let weekday = match chrono::offset::Local::now().date().weekday() {
+            chrono::Weekday::Mon => "Monday",
+            chrono::Weekday::Tue => "Tuesday",
+            chrono::Weekday::Wed => "Wednesday",
+            chrono::Weekday::Thu => "Thursday",
+            chrono::Weekday::Fri => "Friday",
+            chrono::Weekday::Sat => "Saturday",
+            chrono::Weekday::Sun => "Sunday",
+        };
 
-    message.push_str(format!("🧵 {} Reviews 🧵\n", weekday).as_str());
-    message.push_str("(PR's can be hidden from this bot by adding the Stale tag)\n");
-    message.push_str("--------------------\n\n");
+        let mut message = String::new();
 
-    let thread_key = format!("pr-thread-{}", chrono::offset::Local::now());
+        message.push_str(format!("🧵 {} Reviews 🧵\n", weekday).as_str());
+        message.push_str("(PR's can be hidden from this bot by adding the Stale tag)\n");
+        message.push_str("--------------------\n\n");
 
-    info!("Using thread key {}", thread_key);
+        let thread_key = format!("pr-thread-{}", chrono::offset::Local::now());
 
-    GoogleChatMessage::from(message)
-        .send(&webhook_url, &thread_key)
-        .await?;
+        info!("Using thread key {}", thread_key);
 
-    for pull_request in pull_requests_to_review {
-        GoogleChatMessage::from(format!(
-            "<{}|{}#{}> - {}\n",
-            pull_request.html_url(),
-            pull_request.head().repo().name(),
-            pull_request.number(),
-            pull_request.title()
-        ))
-        .send(&webhook_url, &thread_key)
-        .await?;
+        GoogleChatMessage::from(message)
+            .send(&webhook_url, &thread_key)
+            .await?;
+
+        for pull_request in pull_requests_to_review {
+            GoogleChatMessage::from(format!(
+                "<{}|{}#{}> - {}\n",
+                pull_request.html_url(),
+                pull_request.head().repo().name(),
+                pull_request.number(),
+                pull_request.title()
+            ))
+            .send(&webhook_url, &thread_key)
+            .await?;
+        }
+    }
+    else {
+    info!("No open PRs found, no action taken.");
     }
 
     Ok(())


### PR DESCRIPTION
## What does this change?

Currently, prnouncer will post in a channel even if there are no PRs to review. This change means that a message is only posted if there is at least one change to review.

<img width="476" alt="Screenshot 2022-11-23 at 15 06 31" src="https://user-images.githubusercontent.com/67543397/203580192-875b419f-9247-4963-95c6-7365106fcef2.png">

## How to test

Run locally and verify that for a repo with no open PRs, the program completes successfully without posting a message into a channel

## How can we measure success?

Fewer unnecessary posts in channels