### PR TITLE
Improve message formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,9 +147,9 @@ async fn main() -> Result<(), Error> {
 
         message.push_str(format!("🧵 {} Reviews 🧵\n", weekday).as_str());
         message.push_str("(PR's can be hidden from this bot by adding the Stale tag)\n");
-        message.push_str("--------------------\n\n");
-        message.push_str("This message is brought to you by https://github.com/guardian/actions-prnouncer, ");
-        message.push_str("with configuration from https://github.com/guardian/prnouncer-config\n");
+        message.push_str("--------------------\n");
+        message.push_str("This message is brought to you by <https://github.com/guardian/actions-prnouncer|guardian/actions-prnouncer>, ");
+        message.push_str("with configuration from <https://github.com/guardian/prnouncer-config|guardian/prnouncer-config>\n");
         message.push_str("--------------------\n\n");
 
         let thread_key = format!("pr-thread-{}", chrono::offset::Local::now());


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/actions-prnouncer/pull/11 we added some explainer text to the GChat message. It doesn't render in the most ideal way (see below).

In this change we format the message in GChat such that it doesn't render the open graph image.

## How to test
Follow the README instructions to run this project locally, and observe the message.

## Images
### Before
<img width="760" alt="image" src="https://user-images.githubusercontent.com/836140/214929167-ecd0c1d5-0425-4482-8ed4-5731a82a1c02.png">

### After
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/836140/215037328-cb17e14b-15d8-48c4-a6b0-2716a9791cf7.png">
