### PR TITLE
Optionally output relative PR age

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.44",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ log = "0.4.14"
 simple_logger = "2.1.0"
 anyhow = "1.0.53"
 getset = "0.1.2"
-chrono = "0.4.19"
+chrono = { version = "0.4.19", features = ["serde"] }

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
     description: "Comma delimited list of label names to ignore"
     required: true
     default: "Stale"
+  show-pr-age:
+    description: "Include PR age in chat message output"
+    required: false
+    # Values: "true" or "false"
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -29,3 +34,4 @@ runs:
     GITHUB_IGNORED_USERS: ${{ inputs.github-ignored-users }}
     GITHUB_IGNORED_LABELS: ${{ inputs.github-ignored-labels }}
     GOOGLE_WEBHOOK_URL: ${{ inputs.google-webhook-url }}
+    SHOW_PR_AGE: ${{ inputs.show-pr-age }}

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, Utc};
 use getset::Getters;
 use serde::Deserialize;
 
@@ -15,7 +15,7 @@ pub struct GithubPullRequest {
     number: i32,
     head: GithubBranch,
     labels: Vec<GithubLabel>,
-    created_at: DateTime<FixedOffset>,
+    created_at: DateTime<Utc>,
 }
 
 #[derive(Deserialize, Getters, Debug)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use chrono::{DateTime, FixedOffset};
 use getset::Getters;
 use serde::Deserialize;
 
@@ -14,6 +15,7 @@ pub struct GithubPullRequest {
     number: i32,
     head: GithubBranch,
     labels: Vec<GithubLabel>,
+    created_at: DateTime<FixedOffset>,
 }
 
 #[derive(Deserialize, Getters, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,12 +192,9 @@ fn make_message(pull_request: GithubPullRequest, show_pr_age: bool) -> String {
 }
 
 fn get_age(d1: DateTime<Utc>, d2: DateTime<Utc>) -> String {
-    format!(
-        "opened {} ago",
-        match d1.signed_duration_since(d2).num_days() {
-            0 => "less than a day".to_string(),
-            1 => "1 day".to_string(),
-            n => format!("{} days", n),
-        }
-    )
+    match d1.signed_duration_since(d2).num_days() {
+        0 => "opened less than a day ago".to_string(),
+        1 => "opened 1 day ago".to_string(),
+        n => format!("opened {} days ago", n),
+    }
 }


### PR DESCRIPTION
If the `SHOW_PR_AGE` environment variable has value `"true"`, include the PR's relative age (from now) in the output.

The relative ages are:
- "less than a day"
- "1 day"
- "`n` days"

Given the action only runs once/day, I didn't think it was helpful to include units less than a day.

Example output:

<img width="779" alt="image" src="https://github.com/guardian/actions-prnouncer/assets/705427/4bae5dc9-1dee-46f1-bb3d-0c68fcaf82b8">
