### PR TITLE
Make prnouncer work with the new inline threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,11 +143,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -215,6 +214,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -324,11 +324,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -402,12 +401,6 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -565,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -973,15 +966,15 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -994,13 +987,12 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ simple_logger = "2.1.0"
 anyhow = "1.0.53"
 getset = "0.1.2"
 chrono = { version = "0.4.19", features = ["serde"] }
+url = "2.5.0"

--- a/src/google.rs
+++ b/src/google.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GoogleChatMessage {
@@ -16,8 +17,11 @@ impl GoogleChatMessage {
         webhook_url: &String,
         thread_key: &String,
     ) -> Result<GoogleChatMessage> {
+        let webhook_url = Url::parse_with_params(webhook_url,
+        &[("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD")])?;
+
         let response = reqwest::Client::new()
-            .post(webhook_url.replace("{threadKey}", thread_key))
+            .post(webhook_url.as_str().replace("{threadKey}", thread_key))
             .body(serde_json::to_string(&self)?)
             .header("User-Agent", "GU-PR-Bot")
             .send()


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Google has started rolling out Inline threads to all spaces which currently breaks prnouncers ability to create threads.

<img width="684" alt="image" src="https://github.com/guardian/actions-prnouncer/assets/21217225/251c0c08-e427-4831-ab45-b7a3d592ffad">

This PR fixes prnouncers ability to create threads by adding a `messageReplyOption` parameter to the Google chat webhook request which requests a thread be made when prnouncer posts.

## How to test

Ran locally with `cargo run`

<img width="773" alt="image" src="https://github.com/guardian/actions-prnouncer/assets/21217225/806a9ffe-6e14-4af0-9959-99e6370fd74a">
