### PR TITLE
Support webhook urls with missing threadkey parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,5 @@ jobs:
           rust-version: 1.58
       - name: Build
         run: cargo build
+      - name: Test
+        run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,11 +143,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -215,6 +214,7 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -324,11 +324,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -402,12 +401,6 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -565,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -973,15 +966,15 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -994,13 +987,12 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ simple_logger = "2.1.0"
 anyhow = "1.0.53"
 getset = "0.1.2"
 chrono = { version = "0.4.19", features = ["serde"] }
+url = "2.5.0"

--- a/src/google.rs
+++ b/src/google.rs
@@ -12,16 +12,34 @@ impl GoogleChatMessage {
         GoogleChatMessage { text: text }
     }
 
+    /// Build a webhook URL with threadKey set to the provided value, and messageReplyOption set to allow threading.
+    pub fn build_webhook_url(webhook_url: &String, thread_key: &String) -> Result<String> {
+        let url = Url::parse(webhook_url)?;
+        // strip any existing threadKey / messageReplyOption parameters
+        let other_params = url
+            .query_pairs()
+            .filter(|(name, _)| name.ne("threadKey") && name.ne("messageReplyOption"));
+        // rebuild URL with the provided threadKey value, and our desired messageReplyOption
+        let mut updated_url = url.clone();
+        updated_url.query_pairs_mut()
+            .clear()
+            .extend_pairs(other_params)
+            .extend_pairs(&[
+                (&"messageReplyOption".to_string(), &"REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD".to_string()),
+                (&"threadKey".to_string(), thread_key)
+            ]);
+        Ok(updated_url.as_str().to_string())
+    }
+
     pub async fn send(
         self,
         webhook_url: &String,
         thread_key: &String,
     ) -> Result<GoogleChatMessage> {
-        let webhook_url = Url::parse_with_params(webhook_url,
-        &[("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD")])?;
+        let url = GoogleChatMessage::build_webhook_url(&webhook_url, &thread_key)?;
 
         let response = reqwest::Client::new()
-            .post(webhook_url.as_str().replace("{threadKey}", thread_key))
+            .post(url.to_string())
             .body(serde_json::to_string(&self)?)
             .header("User-Agent", "GU-PR-Bot")
             .send()
@@ -34,5 +52,46 @@ impl GoogleChatMessage {
             "Failed to parse JSON when querying {}: {}",
             &webhook_url, response
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_threaded_webhook_with_placeholder() {
+        let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF?threadKey={threadKey}"), &String::from("1234"));
+        match result {
+            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_build_threaded_webhook_without_placeholder() {
+        let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF"), &String::from("1234"));
+        match result {
+            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_preserves_other_existing_params() {
+        let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF?foo=bar"), &String::from("1234"));
+        match result {
+            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?foo=bar&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
+            Err(_) => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_overrides_existing_messagereplyoption_parameter() {
+        let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE"), &String::from("1234"));
+        match result {
+            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
+            Err(_) => assert!(false),
+        }
     }
 }

--- a/src/google.rs
+++ b/src/google.rs
@@ -62,36 +62,24 @@ mod tests {
     #[test]
     fn test_build_threaded_webhook_with_placeholder() {
         let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF?threadKey={threadKey}"), &String::from("1234"));
-        match result {
-            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
-            Err(_) => assert!(false),
-        }
+        assert_eq!(Result::unwrap(result), String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234"))
     }
 
     #[test]
     fn test_build_threaded_webhook_without_placeholder() {
         let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF"), &String::from("1234"));
-        match result {
-            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
-            Err(_) => assert!(false),
-        }
+        assert_eq!(Result::unwrap(result), String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234"))
     }
 
     #[test]
     fn test_preserves_other_existing_params() {
         let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF?foo=bar"), &String::from("1234"));
-        match result {
-            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?foo=bar&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
-            Err(_) => assert!(false),
-        }
+        assert_eq!(Result::unwrap(result), String::from("https://example.com/ABCDEF?foo=bar&messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234"))
     }
 
     #[test]
     fn test_overrides_existing_messagereplyoption_parameter() {
         let result = GoogleChatMessage::build_webhook_url(&String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE"), &String::from("1234"));
-        match result {
-            Ok(url) => assert_eq!(url, String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234")),
-            Err(_) => assert!(false),
-        }
+        assert_eq!(Result::unwrap(result), String::from("https://example.com/ABCDEF?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD&threadKey=1234"))
     }
 }

--- a/src/google.rs
+++ b/src/google.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GoogleChatMessage {
@@ -16,8 +17,11 @@ impl GoogleChatMessage {
         webhook_url: &String,
         thread_key: &String,
     ) -> Result<GoogleChatMessage> {
+        let webhook_url = Url::parse_with_params(webhook_url,
+        &[("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD")])?;
+
         let response = reqwest::Client::new()
-            .post(webhook_url.replace("{threadKey}", thread_key))
+            .post(webhook_url.as_str().replace("{threadKey}", thread_key))
             .body(serde_json::to_string(&self)?)
             .header("User-Agent", "GU-PR-Bot")
             .send()


### PR DESCRIPTION
NOTE: this includes the changes in the [new-inline-threads](https://github.com/guardian/actions-prnouncer/pull/20) PR

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Allows teams to provide a `{threadKey}` placeholder if they want to, but also supports cases where this is not included.

I am led to believe this sometimes casuses problems, when teams forget the parameter.

I'd suggest we officially deprecate the placeholder parameter from here, so that there is a single recommended approach. There's no reference to this placeholder in the README or elsewhere, so I've not made any documentation changes.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've added tests for this logic, but we'll also need to make sure that the existing behaviour still works. I do not have the secrets for testing at my fingertips, so if someone wants to pair with me on testing this locally I'd be grateful!

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Existing configurations should continue to work unchanged, and we might consider updating the webhook URL for one or more of the existing configurations, removing the deprecated threadKey placholder.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Testing this change locally would mitigate the risk of breaking existign configurations.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
