### PR TITLE
Add included users list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Comma delimited list of user ID's to ignore"
     required: true
     default: "49699333"
+  github-included-users:
+    description: "Comma delimited list of user ID's to show"
+    required: false
+    default: ""
   github-ignored-labels:
     description: "Comma delimited list of label names to ignore"
     required: true
@@ -32,6 +36,7 @@ runs:
     GITHUB_REPOSITORIES: ${{ inputs.github-repositories }}
     GITHUB_TOKEN: ${{ inputs.github-token }}
     GITHUB_IGNORED_USERS: ${{ inputs.github-ignored-users }}
+    GITHUB_INCLUDED_USERS: ${{ inputs.github-included-users }}
     GITHUB_IGNORED_LABELS: ${{ inputs.github-ignored-labels }}
     GOOGLE_WEBHOOK_URL: ${{ inputs.google-webhook-url }}
     SHOW_PR_AGE: ${{ inputs.show-pr-age }}

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: "Comma delimited list of user ID's to ignore"
     required: true
     default: "49699333"
-  github-included-users:
+  github-alert-users:
     description: "Comma delimited list of user ID's to show"
     required: false
     default: ""
@@ -36,7 +36,7 @@ runs:
     GITHUB_REPOSITORIES: ${{ inputs.github-repositories }}
     GITHUB_TOKEN: ${{ inputs.github-token }}
     GITHUB_IGNORED_USERS: ${{ inputs.github-ignored-users }}
-    GITHUB_ALERT_USERS: ${{ inputs.github-included-users }}
+    GITHUB_ALERT_USERS: ${{ inputs.github-alert-users }}
     GITHUB_IGNORED_LABELS: ${{ inputs.github-ignored-labels }}
     GOOGLE_WEBHOOK_URL: ${{ inputs.google-webhook-url }}
     SHOW_PR_AGE: ${{ inputs.show-pr-age }}

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
     GITHUB_REPOSITORIES: ${{ inputs.github-repositories }}
     GITHUB_TOKEN: ${{ inputs.github-token }}
     GITHUB_IGNORED_USERS: ${{ inputs.github-ignored-users }}
-    GITHUB_INCLUDED_USERS: ${{ inputs.github-included-users }}
+    GITHUB_ALERT_USERS: ${{ inputs.github-included-users }}
     GITHUB_IGNORED_LABELS: ${{ inputs.github-ignored-labels }}
     GOOGLE_WEBHOOK_URL: ${{ inputs.google-webhook-url }}
     SHOW_PR_AGE: ${{ inputs.show-pr-age }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn scan_repository(
     repository_name: String,
     github_token: &String,
     ignored_users: &Vec<&str>,
-    included_users: &Vec<&str>,
+    alert_users: &Vec<&str>,
     ignored_labels: &Vec<&str>,
 ) -> Result<Vec<GithubPullRequest>, Error> {
     info!("Starting PR scan of {}", repository_name);
@@ -52,10 +52,10 @@ async fn scan_repository(
             continue;
         }
 
-        if !included_users.contains(&pull_request.user().id().to_string().as_str()) {
-            info!("included users: {:?}", included_users);
+        if !alert_users.contains(&pull_request.user().id().to_string().as_str()) {
+            info!("Users to alert: {:?}", alert_users);
             info!(
-                "Ignoring PR {}({}) as it was raised by a user not included in the only_users list {}({})",
+                "Ignoring PR {}({}) as it was raised by a user not included in the alert users list {}({})",
                 pull_request.id(),
                 pull_request.title(),
                 pull_request.user().id(),
@@ -126,8 +126,8 @@ async fn main() -> Result<(), Error> {
         env::var("GOOGLE_WEBHOOK_URL").context("GOOGLE_WEBHOOK_URL must be set")?;
     let ignored_users: String = env::var("GITHUB_IGNORED_USERS").unwrap_or("".to_string());
     let ignored_users: Vec<&str> = ignored_users.split(",").collect();
-    let included_users: String = env::var("GITHUB_INCLUDED_USERS").unwrap_or("".to_string());
-    let included_users: Vec<&str> = included_users.split(",").collect();
+    let alert_users: String = env::var("GITHUB_ALERT_USERS").unwrap_or("".to_string());
+    let alert_users: Vec<&str> = alert_users.split(",").collect();
     let ignored_labels: String = env::var("GITHUB_IGNORED_LABELS").unwrap_or("".to_string());
     let ignored_labels: Vec<&str> = ignored_labels.split(",").collect();
     let show_pr_age: bool = env::var("SHOW_PR_AGE")
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Error> {
                 repository.to_string(),
                 &github_token,
                 &ignored_users,
-                &included_users,
+                &alert_users,
                 &ignored_labels,
             )
             .await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ async fn scan_repository(
     repository_name: String,
     github_token: &String,
     ignored_users: &Vec<&str>,
+    included_users: &Vec<&str>,
     ignored_labels: &Vec<&str>,
 ) -> Result<Vec<GithubPullRequest>, Error> {
     info!("Starting PR scan of {}", repository_name);
@@ -43,6 +44,18 @@ async fn scan_repository(
         if ignored_users.contains(&pull_request.user().id().to_string().as_str()) {
             info!(
                 "Ignoring PR {}({}) as it was raised by an ignored user {}({})",
+                pull_request.id(),
+                pull_request.title(),
+                pull_request.user().id(),
+                pull_request.user().login()
+            );
+            continue;
+        }
+
+        if !included_users.contains(&pull_request.user().id().to_string().as_str()) {
+            info!("included users: {:?}", included_users);
+            info!(
+                "Ignoring PR {}({}) as it was raised by a user not included in the only_users list {}({})",
                 pull_request.id(),
                 pull_request.title(),
                 pull_request.user().id(),
@@ -113,6 +126,8 @@ async fn main() -> Result<(), Error> {
         env::var("GOOGLE_WEBHOOK_URL").context("GOOGLE_WEBHOOK_URL must be set")?;
     let ignored_users: String = env::var("GITHUB_IGNORED_USERS").unwrap_or("".to_string());
     let ignored_users: Vec<&str> = ignored_users.split(",").collect();
+    let included_users: String = env::var("GITHUB_INCLUDED_USERS").unwrap_or("".to_string());
+    let included_users: Vec<&str> = included_users.split(",").collect();
     let ignored_labels: String = env::var("GITHUB_IGNORED_LABELS").unwrap_or("".to_string());
     let ignored_labels: Vec<&str> = ignored_labels.split(",").collect();
     let show_pr_age: bool = env::var("SHOW_PR_AGE")
@@ -127,6 +142,7 @@ async fn main() -> Result<(), Error> {
                 repository.to_string(),
                 &github_token,
                 &ignored_users,
+                &included_users,
                 &ignored_labels,
             )
             .await?,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Co-authored-by: @lindseydew 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We would like to introduce an option to make the PR announcer only announce PRs from select users e.g. scala stewart. 

## How to test
We have tested this on our MSS dev chat, which worked as expected.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
We can now make the PR announcer alert PRs from a select list of users.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
We have set this new flag to be optional so existing announcers should not be affected.
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

