### PR TITLE
Model numbers as `usize`

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -6,13 +6,13 @@ use serde::Deserialize;
 #[derive(Deserialize, Getters, Debug)]
 #[getset(get = "pub", get_copy = "pub")]
 pub struct GithubPullRequest {
-    id: i32,
+    id: usize,
     url: String,
     html_url: String,
     title: String,
     user: GithubUser,
     draft: bool,
-    number: i32,
+    number: usize,
     head: GithubBranch,
     labels: Vec<GithubLabel>,
     created_at: DateTime<Utc>,
@@ -39,14 +39,14 @@ pub struct GithubLabel {
 #[derive(Deserialize, Getters, Debug)]
 #[getset(get = "pub")]
 pub struct GithubUser {
-    id: i32,
+    id: usize,
     login: String,
 }
 
 #[derive(Deserialize, Getters, Debug)]
 #[getset(get = "pub")]
 pub struct GithubReview {
-    id: i32,
+    id: usize,
     state: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn scan_repository(
     repository_name: String,
     github_token: &String,
     ignored_users: &Vec<&str>,
-    announced_users: &Option<Vec<i32>>,
+    announced_users: &Option<Vec<usize>>,
     ignored_labels: &Vec<&str>,
 ) -> Result<Vec<GithubPullRequest>, Error> {
     info!("Starting PR scan of {}", repository_name);
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Error> {
         env::var("GOOGLE_WEBHOOK_URL").context("GOOGLE_WEBHOOK_URL must be set")?;
     let ignored_users: String = env::var("GITHUB_IGNORED_USERS").unwrap_or("".to_string());
     let ignored_users: Vec<&str> = ignored_users.split(",").collect();
-    let announced_users: Option<Vec<i32>> = env::var("GITHUB_ANNOUNCED_USERS")
+    let announced_users: Option<Vec<usize>> = env::var("GITHUB_ANNOUNCED_USERS")
         .ok()
         .and_then(|s| {
             if s.is_empty() {


### PR DESCRIPTION
## What does this change?

Changes the schemas modelling the Github API, specifically turning all `i32` into `usize`.

## Why?

An action recently failed with this error:
```
Caused by:
    invalid value: integer `2152714260`, expected i32 at line 1 column 17
```
because the ID of the pull request was greater than [`i32::MAX`](https://doc.rust-lang.org/std/primitive.i32.html#associatedconstant.MAX). Since IDs are generally positive integer numbers, it's fine to switch to an unsigned integer type. Specifically, `usize`'s max value in this case is $2^{64}-1$, compared to `i32`'s $2^{31}-1$, which is *quite a lot* more. 