### PR TITLE
Run action from published Docker image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - ms-publish-docker
 
 jobs:
   publish:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -11,6 +11,11 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,34 @@
+name: Publish image to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches: main
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: ghcr.io/guardian
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1 # v6.2.0
+        with:
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/guardian/actions-prnouncer:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -38,4 +38,4 @@ jobs:
           tags: ghcr.io/guardian/actions-prnouncer:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: true
+          provenance: false

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,7 +3,9 @@ name: Publish image to GHCR
 on:
   workflow_dispatch:
   push:
-    branches: main
+    branches:
+      - main
+      - ms-publish-docker
 
 jobs:
   publish:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - "ms-publish-docker"
 
 jobs:
   publish:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - "ms-publish-docker"
 
 jobs:
   publish:
@@ -13,7 +14,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.58 as build
+FROM rust:latest AS build
 
 COPY ./src ./src
 COPY ./Cargo.toml ./Cargo.toml

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     default: "false"
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://gchr.io/guardian/actions-prnouncer"
   env:
     GITHUB_REPOSITORIES: ${{ inputs.github-repositories }}
     GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
## What does this change?

Adds a new workflow to publish a Docker image, so that the actions runs the image instead of building from source.

## Why?
Currently, every time the action is invoked, the image is built from a Dockerfile and run, which takes 2~3 minutes per run.
Now that the action is published, the action will run that instead, skipping the build step. This should save a lot of time!

Closes #9 
