### PR TITLE
Pin Rust version, update debian

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/guardian/actions-prnouncer:latest
+          tags: ghcr.io/guardian/actions-prnouncer:latest,ghcr.io/guardian/actions-prnouncer:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS build
+FROM rust:1.79 AS build
 
 COPY ./src ./src
 COPY ./Cargo.toml ./Cargo.toml
@@ -7,7 +7,7 @@ COPY ./Cargo.lock ./Cargo.lock
 RUN cargo build --release
 
 # Rust has issues with Alpine at the moment due to its requirement on glibc, so unfortunately we do need to use a slightly larger distro.
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 


### PR DESCRIPTION
## What does this change?

As per PR title. rust:1.79 uses debian-bookworm, so we match the version in the second layer of the Dockerfile.

## Why?

To avoid this annoying error:

```
google-chats-pr-announcer: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

## How to test

You can build this locally
```bash
docker build -t prnouncer
docker run prnouncer
``` 
And see that it works.