### PR TITLE
Do not log if repo is private

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,18 +263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,7 +274,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "getset",
  "log",
  "reqwest",
  "serde",
@@ -626,7 +613,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn",
 ]
 
 [[package]]
@@ -699,30 +686,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -880,7 +843,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn",
 ]
 
 [[package]]
@@ -951,17 +914,6 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1089,7 +1041,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn",
 ]
 
 [[package]]
@@ -1185,12 +1137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,7 +1172,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1260,7 +1206,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ serde_json = "1.0.79"
 log = "0.4.14"
 simple_logger = "2.1.0"
 anyhow = "1.0.53"
-getset = "0.1.2"
 chrono = { version = "0.4.19", features = ["serde"] }
 url = "2.5.0"

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,53 +1,47 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use getset::Getters;
 use serde::Deserialize;
 
-#[derive(Deserialize, Getters, Debug)]
-#[getset(get = "pub", get_copy = "pub")]
+#[derive(Deserialize, Debug)]
 pub struct GithubPullRequest {
-    id: usize,
-    url: String,
-    html_url: String,
-    title: String,
-    user: GithubUser,
-    draft: bool,
-    number: usize,
-    head: GithubBranch,
-    labels: Vec<GithubLabel>,
-    created_at: DateTime<Utc>,
+    pub id: usize,
+    pub url: String,
+    pub html_url: String,
+    pub title: String,
+    pub user: GithubUser,
+    pub draft: bool,
+    pub number: usize,
+    pub head: GithubBranch,
+    pub labels: Vec<GithubLabel>,
+    pub created_at: DateTime<Utc>,
 }
 
-#[derive(Deserialize, Getters, Debug)]
-#[getset(get = "pub", get_copy = "pub")]
+#[derive(Deserialize, Debug)]
 pub struct GithubBranch {
-    repo: GithubRepository,
+    pub repo: GithubRepository,
 }
 
-#[derive(Deserialize, Getters, Debug)]
-#[getset(get = "pub", get_copy = "pub")]
+#[derive(Deserialize, Debug)]
 pub struct GithubRepository {
-    name: String,
+    pub name: String,
+    pub visibility: String,
 }
 
-#[derive(Deserialize, Getters, Debug)]
-#[getset(get = "pub", get_copy = "pub")]
+#[derive(Deserialize, Debug)]
 pub struct GithubLabel {
-    name: String,
+    pub name: String,
 }
 
-#[derive(Deserialize, Getters, Debug)]
-#[getset(get = "pub")]
+#[derive(Deserialize, Debug)]
 pub struct GithubUser {
-    id: usize,
-    login: String,
+    pub id: usize,
+    pub login: String,
 }
 
-#[derive(Deserialize, Getters, Debug)]
-#[getset(get = "pub")]
+#[derive(Deserialize, Debug)]
 pub struct GithubReview {
-    id: usize,
-    state: String,
+    pub id: usize,
+    pub state: String,
 }
 
 impl GithubPullRequest {
@@ -74,7 +68,7 @@ impl GithubPullRequest {
     }
 
     pub async fn reviews(&self, token: &str) -> Result<Vec<GithubReview>> {
-        let api_url = format!("{}/reviews", self.url());
+        let api_url = format!("{}/reviews", self.url);
 
         let response = reqwest::Client::new()
             .get(&api_url)


### PR DESCRIPTION
## What does this change?

The action is outputting detailed logs, which is not great if a repository is private.
For now, I think it's easier to simply not print logs if a repository is private, unless there's a compelling strategy to adopt a different strategy (such as making the `prnouncer-config` repo itself private)

I've also got rid of the `getset` library which inflates the binary size a little bit because it produces generated code for the derived traits where a `pub` modifier on the structs is enough.
