### PR TITLE
feat: Demarcate bot raised PRs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,8 +205,14 @@ async fn main() -> Result<(), Error> {
 }
 
 fn make_message(pull_request: GithubPullRequest, show_pr_age: bool) -> String {
+    let prefix = match pull_request.user.login.contains("[bot]") {
+        true => "🤖🤖🤖 ".to_string(),
+        false => "".to_string(),
+    };
+
     let message = format!(
-        "<{}|{}#{}> - {}",
+        "{}<{}|{}#{}> - {}",
+        prefix,
         pull_request.html_url.replace("https://", ""),
         pull_request.head.repo.name,
         pull_request.number,
@@ -218,7 +224,10 @@ fn make_message(pull_request: GithubPullRequest, show_pr_age: bool) -> String {
         false => "".to_string(),
     };
 
-    format!("{}{}\n", message, age_output)
+    format!(
+        "{}{} \n\nby {}\n",
+        message, age_output, pull_request.user.login
+    )
 }
 
 fn get_age(d1: DateTime<Utc>, d2: DateTime<Utc>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,9 +205,10 @@ async fn main() -> Result<(), Error> {
 }
 
 fn make_message(pull_request: GithubPullRequest, show_pr_age: bool) -> String {
-    let prefix = match pull_request.user.login.contains("[bot]") {
-        true => "🤖🤖🤖 ".to_string(),
-        false => "".to_string(),
+    let prefix = if pull_request.user.login.contains("[bot]") {
+        "🤖🤖🤖 ".to_string()
+    } else {
+        "".to_string()
     };
 
     let message = format!(
@@ -219,9 +220,10 @@ fn make_message(pull_request: GithubPullRequest, show_pr_age: bool) -> String {
         pull_request.title
     );
 
-    let age_output = match show_pr_age {
-        true => format!(" - (_{}_)", get_age(Utc::now(), pull_request.created_at)),
-        false => "".to_string(),
+    let age_output = if show_pr_age {
+        format!(" - (_{}_)", get_age(Utc::now(), pull_request.created_at))
+    } else {
+        "".to_string()
     };
 
     format!(


### PR DESCRIPTION
## What does this change?
On the assumption that PRs raised by a human should be prioritised, add a prefix to bot raised PRs to provide a visual difference between the two. Also add the PR author to the message.

<details><summary>Alternative solution</summary>
<p>

An alternative to this would be to group bot PRs together. This would then allow a summary to be provided too, for example:

> 🧵 Wednesday Reviews 🧵
> (PR's can be hidden from this bot by adding the Stale tag)
> 
> Total PRs: 10 (7 raised by bots)

However, this would require more of a refactor.

</p>
</details> 

## How to test
Follow the instructions in the README to run locally.

## How can we measure success?
PRs raised from colleagues are triaged faster. NOTE: I've not got any metrics to suggest this is actually a problem, just anecdotal experience.

## Have we considered potential risks?
Are the messages too noisy?

## Images

### Before
<img width="528" alt="image" src="https://github.com/user-attachments/assets/25ac43c9-c95f-439f-9125-417a4cd927fa">

### After
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ad082d24-b78f-44dc-9c6d-5e6f2e69cee0">
