### PR TITLE
fix: Handle 429 responses from Chat API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ async fn main() -> Result<(), Error> {
         info!("Using thread key {}", thread_key);
 
         GoogleChatMessage::from(message)
-            .send(&webhook_url, &thread_key)
+            .send(&webhook_url, &thread_key, 0)
             .await?;
 
         for pull_request in pull_requests_to_review {
@@ -198,7 +198,7 @@ async fn main() -> Result<(), Error> {
                 pull_request.head.repo.name, pull_request.number
             );
             GoogleChatMessage::from(make_message(pull_request, show_pr_age))
-                .send(&webhook_url, &thread_key)
+                .send(&webhook_url, &thread_key, 0)
                 .await?;
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,10 @@ async fn main() -> Result<(), Error> {
             .await?;
 
         for pull_request in pull_requests_to_review {
+            info!(
+                "Sending message for PR {} #{}",
+                pull_request.head.repo.name, pull_request.number
+            );
             GoogleChatMessage::from(make_message(pull_request, show_pr_age))
                 .send(&webhook_url, &thread_key)
                 .await?;


### PR DESCRIPTION
## What does this change?
Retry a Google Chat API request 1.5 seconds after receipt of a 429 response. This should help avoid the [rate limit](https://developers.google.com/workspace/chat/limits) of this API (60 requests per minute).

<details><summary>Example output w/unhandled 429 responses</summary>
<p>

![image](https://github.com/user-attachments/assets/6a66b055-0427-4ecc-830d-9da226e88e25)

</p>
</details>

## How to test
Following the README instructions:
- Run `main`, observe a 429 response and program exit
- Run this branch and observe a retry on a 429 response

Alternatively, see https://github.com/guardian/prnouncer-config/pull/71 and it's [execution](https://github.com/guardian/prnouncer-config/actions/runs/11679203311/job/32519906013).

---
Fixes #40.