### PR TITLE
Prioritise PRs from humans

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,17 @@ async fn main() -> Result<(), Error> {
         );
     }
 
+    //Prioritise PRs from humans
+    pull_requests_to_review.sort_by(|a, b| {
+        if a.user.r#type.to_lowercase() == "bot" && b.user.r#type.to_lowercase() != "bot" {
+            std::cmp::Ordering::Greater
+        } else if a.user.r#type.to_lowercase() != "bot" && b.user.r#type.to_lowercase() == "bot" {
+            std::cmp::Ordering::Less
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+
     if !pull_requests_to_review.is_empty() {
         let weekday = match chrono::offset::Local::now().date_naive().weekday() {
             chrono::Weekday::Mon => "Monday",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Before sending PR announcements, rearrange them so that PRs raised by humans are prioritised.

If we passed `GITHUB_REPOSITORIES=guardian/a,guardian/b`, and they have the following PRs open


|guardian/a|guardian/b|
|----------|----------|
|PR 1 - 🤖|PR 1 - 🤖|
|PR 2 - 👤|PR 2 - 👤|

we can compare the ordering of PRs before and after this change. Previously, their ordering only depended on the order in which the repositories were specified in config. Now, they are primarily ordered based on whether or not a bot raised the PR, and only then, by the config order.

|before                |after                |
|----------------------|---------------------|
|guardian/a - PR 1 - 🤖|guardian/a - PR 2 - 👤|
|guardian/a - PR 2 - 👤|guardian/b - PR 2 - 👤|
|guardian/b - PR 1 - 🤖|guardian/a - PR 1 - 🤖|
|guardian/b - PR 2 - 👤|guardian/b - PR 1 - 🤖|

This is useful for teams that have large numbers of dependency bumps, or other automated actions. While important to keep on top of, they are usually a lower priority than other work done by humans. This is especially useful for teams that have large numbers of PRs to go over every day, or in scenarios where a bot runs on a schedule (i.e. dependabot raising all its PRs at once), potentially making it difficult to spot other PRs.

## How to test

Run this branch locally

## How can we measure success?

Teams are able to spot and prioritise PRs from humans more effectively
